### PR TITLE
feat: add default whitelist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  SKIP_INSTALL_SIMPLE_GIT_HOOKS: true
+
 jobs:
   contributors:
     if: "${{ github.event.head_commit.message != 'build: contributors' }}"
@@ -19,11 +22,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+      - name: Install
+        run: pnpm install --dangerously-allow-all-builds
       - name: Contributors
         run: |
-          git config --global user.email ${{ secrets.GIT_EMAIL }}
-          git config --global user.name ${{ secrets.GIT_USERNAME }}
-          npm run contributors
+          git config --global user.email "${{ secrets.GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.GIT_USERNAME }}"
+          pnpm contributors
       - name: Push changes
         run: |
           git push origin ${{ github.head_ref }}
@@ -51,19 +60,19 @@ jobs:
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Test
-        run: npm test
-      # - name: Report
-      #   run: npx c8 report --reporter=text-lcov > coverage/lcov.info
-      # - name: Coverage
-      #   uses: coverallsapp/github-action@main
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm test
+      - name: Report
+        run: npx c8 report --reporter=text-lcov > coverage/lcov.info
+      - name: Coverage
+        uses: coverallsapp/github-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          git config --global user.email ${{ secrets.GIT_EMAIL }}
-          git config --global user.name ${{ secrets.GIT_USERNAME }}
+          git config --global user.email "${{ secrets.GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.GIT_USERNAME }}"
           git pull origin master
-          npm run release
+          pnpm release

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+env:
+  SKIP_INSTALL_SIMPLE_GIT_HOOKS: true
+
 jobs:
   test:
     if: github.ref != 'refs/heads/master'
@@ -28,10 +31,10 @@ jobs:
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Test
-        run: npm test
-      # - name: Report
-      #   run: npx c8 report --reporter=text-lcov > coverage/lcov.info
-      # - name: Coverage
-      #   uses: coverallsapp/github-action@main
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm test
+      - name: Report
+        run: npx c8 report --reporter=text-lcov > coverage/lcov.info
+      - name: Coverage
+        uses: coverallsapp/github-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -43,14 +43,16 @@
   "devDependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
+    "ava": "latest",
+    "c8": "latest",
     "ci-publish": "latest",
+    "conventional-changelog-cli": "latest",
     "finepack": "latest",
     "git-authors-cli": "latest",
     "github-generate-release": "latest",
     "nano-staged": "latest",
     "simple-git-hooks": "latest",
     "standard": "latest",
-    "standard-markdown": "latest",
     "standard-version": "latest"
   },
   "engines": {
@@ -62,15 +64,19 @@
   ],
   "scripts": {
     "clean": "rm -rf node_modules",
-    "contributors": "(npx git-authors-cli && npx finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
-    "lint": "standard-markdown README.md && standard",
-    "postrelease": "npm run release:tags && npm run release:github && (ci-publish || npm publish --access=public)",
+    "contributors": "(git-authors-cli && finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
+    "lint": "standard",
+    "postrelease": "pnpm release:tags && pnpm release:github && (ci-publish || pnpm publish --access=public)",
     "pretest": "npm run lint",
     "pretty": "prettier-standard index.js {core,test,bin}/**/*.js --single-quote",
-    "release": "standard-version -a",
+    "release": "pnpm release:version && pnpm release:changelog && pnpm release:commit && pnpm release:tag",
+    "release:changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s",
+    "release:commit": "git add package.json CHANGELOG.md && git commit -m \"chore(release): $(node -p \"require('./package.json').version\")\"",
     "release:github": "github-generate-release",
-    "release:tags": "git push --follow-tags origin HEAD:master",
-    "test": "ava"
+    "release:tag": "git tag -a v$(node -p \"require('./package.json').version\") -m \"v$(node -p \"require('./package.json').version\")\"",
+    "release:tags": "git push origin HEAD:master --follow-tags",
+    "release:version": "standard-version --skip.changelog --skip.commit --skip.tag",
+    "test": "c8 ava --timeout 30s"
   },
   "preferGlobal": true,
   "license": "MIT",
@@ -88,9 +94,6 @@
     "*.js": [
       "npx @kikobeats/prettier-standard",
       "standard --fix"
-    ],
-    "*.md": [
-      "standard-markdown"
     ],
     "package.json": [
       "finepack"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "release": "standard-version -a",
     "release:github": "github-generate-release",
     "release:tags": "git push --follow-tags origin HEAD:master",
-    "test": "exit 0"
+    "test": "ava"
   },
   "preferGlobal": true,
   "license": "MIT",

--- a/src/default/whitelist.js
+++ b/src/default/whitelist.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = ['.npmrc']

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -4,7 +4,8 @@ const { get } = require('lodash')
 const JoyCon = require('joycon')
 
 const DEFAULT = {
-  blacklist: require('./default/blacklist')
+  blacklist: require('./default/blacklist'),
+  whitelist: require('./default/whitelist')
 }
 
 const loadConfig = async cwd => {

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -11,21 +11,31 @@ const untracked = require('../src')
 const blacklist = require('../src/default/blacklist')
 const whitelist = require('../src/default/whitelist')
 
+const createFixture = (opts = {}) => {
+  const dir = join(tmpdir(), `untracked-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'test-pkg', ...opts })
+  )
+  return dir
+}
+
 test('output contains start and finish markers', async t => {
-  const output = await untracked()
+  const output = await untracked({ cwd: createFixture() })
   t.true(output.startsWith(untracked.START))
   t.true(output.endsWith(untracked.FINISH))
 })
 
 test('blacklist entries are present in output', async t => {
-  const output = await untracked()
+  const output = await untracked({ cwd: createFixture() })
   for (const entry of blacklist.slice(0, 5)) {
     t.true(output.includes(entry), `missing blacklist entry: ${entry}`)
   }
 })
 
 test('.npmrc is whitelisted by default', async t => {
-  const output = await untracked()
+  const output = await untracked({ cwd: createFixture() })
   t.true(output.includes('!.npmrc'))
 })
 
@@ -34,18 +44,12 @@ test('default whitelist includes .npmrc', t => {
 })
 
 test('user config extends defaults', async t => {
-  const dir = join(tmpdir(), `untracked-test-${Date.now()}`)
-  mkdirSync(dir, { recursive: true })
-  writeFileSync(
-    join(dir, 'package.json'),
-    JSON.stringify({
-      name: 'test-pkg',
-      untracked: {
-        blacklist: ['custom-ignore'],
-        whitelist: ['custom-keep']
-      }
-    })
-  )
+  const dir = createFixture({
+    untracked: {
+      blacklist: ['custom-ignore'],
+      whitelist: ['custom-keep']
+    }
+  })
   const output = await untracked({ cwd: dir })
   t.true(output.includes('custom-ignore'))
   t.true(output.includes('!custom-keep'))
@@ -53,13 +57,7 @@ test('user config extends defaults', async t => {
 })
 
 test('write mode replaces content between markers', async t => {
-  const dir = join(tmpdir(), `untracked-write-${Date.now()}`)
-  mkdirSync(dir, { recursive: true })
-  writeFileSync(
-    join(dir, 'package.json'),
-    JSON.stringify({ name: 'test-pkg' })
-  )
-
+  const dir = createFixture()
   const filepath = join(dir, '.gitignore')
   writeFileSync(
     filepath,
@@ -77,8 +75,7 @@ test('write mode replaces content between markers', async t => {
 })
 
 test('write mode throws when markers are missing', async t => {
-  const dir = join(tmpdir(), `untracked-nomarker-${Date.now()}`)
-  mkdirSync(dir, { recursive: true })
+  const dir = createFixture()
   const filepath = join(dir, '.gitignore')
   writeFileSync(filepath, 'no markers here')
 

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -1,0 +1,88 @@
+import { writeFileSync, mkdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createRequire } from 'module'
+
+import test from 'ava'
+
+const require = createRequire(import.meta.url)
+
+const untracked = require('../src')
+const blacklist = require('../src/default/blacklist')
+const whitelist = require('../src/default/whitelist')
+
+test('output contains start and finish markers', async t => {
+  const output = await untracked()
+  t.true(output.startsWith(untracked.START))
+  t.true(output.endsWith(untracked.FINISH))
+})
+
+test('blacklist entries are present in output', async t => {
+  const output = await untracked()
+  for (const entry of blacklist.slice(0, 5)) {
+    t.true(output.includes(entry), `missing blacklist entry: ${entry}`)
+  }
+})
+
+test('.npmrc is whitelisted by default', async t => {
+  const output = await untracked()
+  t.true(output.includes('!.npmrc'))
+})
+
+test('default whitelist includes .npmrc', t => {
+  t.true(whitelist.includes('.npmrc'))
+})
+
+test('user config extends defaults', async t => {
+  const dir = join(tmpdir(), `untracked-test-${Date.now()}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      name: 'test-pkg',
+      untracked: {
+        blacklist: ['custom-ignore'],
+        whitelist: ['custom-keep']
+      }
+    })
+  )
+  const output = await untracked({ cwd: dir })
+  t.true(output.includes('custom-ignore'))
+  t.true(output.includes('!custom-keep'))
+  t.true(output.includes('!.npmrc'), '.npmrc should still be whitelisted')
+})
+
+test('write mode replaces content between markers', async t => {
+  const dir = join(tmpdir(), `untracked-write-${Date.now()}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'test-pkg' })
+  )
+
+  const filepath = join(dir, '.gitignore')
+  writeFileSync(
+    filepath,
+    `# header\n${untracked.START}\nold content\n${untracked.FINISH}\n# footer`
+  )
+
+  await untracked.write(filepath, { cwd: dir })
+  const result = readFileSync(filepath, 'utf8')
+
+  t.true(result.includes('# header'))
+  t.true(result.includes('# footer'))
+  t.false(result.includes('old content'))
+  t.true(result.includes(untracked.START))
+  t.true(result.includes(untracked.FINISH))
+})
+
+test('write mode throws when markers are missing', async t => {
+  const dir = join(tmpdir(), `untracked-nomarker-${Date.now()}`)
+  mkdirSync(dir, { recursive: true })
+  const filepath = join(dir, '.gitignore')
+  writeFileSync(filepath, 'no markers here')
+
+  await t.throwsAsync(() => untracked.write(filepath, { cwd: dir }), {
+    message: /Markers not found/
+  })
+})


### PR DESCRIPTION
Closes #56


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to default ignore output (whitelisting `.npmrc`); remaining edits are CI, scripts, and tests with no auth or production runtime impact.
> 
> **Overview**
> Adds a **default whitelist** so generated ignore rules include negation patterns (starting with **`.npmrc`** via `!.npmrc`), merged with user `untracked` config the same way as the existing blacklist defaults.
> 
> **CI and tooling** move contributors/release/PR jobs to **pnpm** (install, test, release, contributors), set **`SKIP_INSTALL_SIMPLE_GIT_HOOKS`** in workflows, quote git identity secrets, and re-enable **c8 → Coveralls** on test jobs. **`package.json`** replaces the no-op test with **`c8` + `ava`**, drops markdown lint from nano-staged, and splits **`release`** into version/changelog/commit/tag steps.
> 
> **Tests** in `test/index.mjs` cover markers, blacklist snippets, default and extended whitelist, and write-mode marker replacement/errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731a56aa7726a84620f92f73b1cd9eaae018cd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->