### PR TITLE
perf: replace execSync+lodash with tinyspawn --parseable

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   ],
   "dependencies": {
     "joycon": "~3.1.1",
-    "lodash": "~4.18.1",
     "mri": "~1.2.0",
+    "tinyspawn": "~1.5.7",
     "update-notifier": "~5.1.0"
   },
   "devDependencies": {

--- a/src/getProductionDeps.js
+++ b/src/getProductionDeps.js
@@ -1,33 +1,20 @@
 'use strict'
 
-const { isObject, forEach, get } = require('lodash')
-const { execSync } = require('child_process')
+const $ = require('tinyspawn')
 
-const flattenDeps = (pkg, acc) => {
-  const dependencies = get(pkg, 'dependencies')
-  if (!isObject(dependencies)) return
-
-  forEach(dependencies, (dependencyPkg, dependencyName) => {
-    acc[dependencyName] = true
-    flattenDeps(dependencyPkg, acc)
+module.exports = async cwd => {
+  const { stdout } = await $('npm ls --prod --all --parseable', {
+    cwd,
+    reject: false
   })
-}
 
-const readProductionDeps = () => {
-  let output
-  try {
-    output = execSync('npm ls --prod --all --json 2> /dev/null', {
-      maxBuffer: 1024 * 1024 * 500
-    })
-  } catch (err) {
-    output = err.stdout
+  const deps = new Set()
+
+  for (const line of stdout.split('\n')) {
+    const i = line.lastIndexOf('node_modules/')
+    if (i === -1) continue
+    deps.add(line.slice(i + 'node_modules/'.length))
   }
-  return JSON.parse(output.toString())
-}
 
-module.exports = () => {
-  const deps = {}
-  const pkg = readProductionDeps()
-  flattenDeps(pkg, deps)
-  return Object.keys(deps)
+  return [...deps]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ const untrackedWrite = async (filepath, opts) => {
 }
 
 const untracked = async opts => {
+  const { cwd = process.cwd() } = opts || {}
   const { blacklist, whitelist } = await loadConfig(opts)
   const removeBlacklistedDeps = dep => !blacklist.includes(dep)
   const includeNamespaces = dep => {
@@ -40,7 +41,7 @@ const untracked = async opts => {
     return dep.indexOf('/') >= 0 ? dep.split('/')[0] : dep
   }
 
-  const productionDeps = getProductionDeps()
+  const productionDeps = (await getProductionDeps(cwd))
     .filter(removeBlacklistedDeps)
     .map(includeNamespaces)
 

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { get } = require('lodash')
 const JoyCon = require('joycon')
 
 const DEFAULT = {
@@ -26,7 +25,7 @@ const loadConfig = async cwd => {
 }
 
 const createCollection = (configFile, propName) => {
-  const collection = new Set(get(configFile, propName, []))
+  const collection = new Set(configFile[propName] || [])
   DEFAULT[propName] && DEFAULT[propName].forEach(item => collection.add(item))
   return Array.from(collection)
 }
@@ -35,7 +34,7 @@ module.exports = async ({ cwd = process.cwd() } = {}) => {
   const configFile = await loadConfig(cwd)
 
   return {
-    write: get(configFile, 'write', false),
+    write: configFile.write || false,
     whitelist: createCollection(configFile, 'whitelist'),
     blacklist: createCollection(configFile, 'blacklist')
   }


### PR DESCRIPTION
500MB maxBuffer JSON tree was overkill; --parseable streams flat paths at a fraction of the memory. Drops lodash entirely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core ignore-list generation changes how production deps are resolved; accuracy could shift for npm failure or unusual `node_modules` layouts compared to the previous JSON flatten.
> 
> **Overview**
> **Production dependency discovery** no longer runs `npm ls` with a 500MB JSON buffer and lodash tree flattening. It now shells out via `tinyspawn` with `npm ls --prod --all --parseable`, walks each line for `node_modules/` segments, and returns a deduped package name list. **`getProductionDeps` is async** and takes a `cwd`; `untracked` passes `opts.cwd` (default `process.cwd()`).
> 
> **Dependencies:** `lodash` is removed; **`tinyspawn`** is added. Config loading in `load-config.js` uses plain property access instead of `lodash.get`.
> 
> **Risk note:** Output depends on parseable path lines rather than the JSON tree—behavior should match for typical installs but edge cases (npm errors, unusual layouts) may differ from the old stdout-on-error JSON path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51113c22dd9dd4b1ddf540a425dbc9158c4f8dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->